### PR TITLE
Configurable `m.notice` support

### DIFF
--- a/base-config.yaml
+++ b/base-config.yaml
@@ -13,6 +13,4 @@ youtube:
   enabled: True
   info: True
   thumbnail: True
-msgtypes:
-  text: True
-  notice: False
+respond_to_notice: False

--- a/base-config.yaml
+++ b/base-config.yaml
@@ -13,3 +13,6 @@ youtube:
   enabled: True
   info: True
   thumbnail: True
+msgtypes:
+  text: True
+  notice: False

--- a/socialmediadownload.py
+++ b/socialmediadownload.py
@@ -20,14 +20,7 @@ class Config(BaseProxyConfig):
             for suffix in ["enabled", "info", "image", "video", "thumbnail"]:
                 helper.copy(f"{prefix}.{suffix}")
 
-        for suffix in ["text", "notice"]:
-            helper.copy(f"msgtypes.{suffix}")
-
-#        helper.base["msgtypes"] = tuple()
-#        if "msgtypes.text" in helper.source and helper.source["msgtypes.text"]:
-#            helper.base["msgtypes"] += (MessageType.TEXT,)
-#        if "msgtypes.notice" in helper.source and helper.source["msgtypes.notice"]:
-#            helper.base["msgtypes"] += (MessageType.NOTICE,)
+        helper.copy("respond_to_notice")
 
 reddit_pattern = re.compile(r"((?:https?:)?\/\/)?((?:www|m|old|nm)\.)?((?:reddit\.com|redd\.it))(\/r\/[^/]+\/(?:comments|s)\/[a-zA-Z0-9_\-]+)")
 instagram_pattern = re.compile(r"(?:https?:\/\/)?(?:www\.)?instagram\.com\/?([a-zA-Z0-9\.\_\-]+)?\/([p]+)?([reel]+)?([tv]+)?([stories]+)?\/([a-zA-Z0-9\-\_\.]+)\/?([0-9]+)?")
@@ -42,20 +35,12 @@ class SocialMediaDownloadPlugin(Plugin):
         return Config
 
     @event.on(EventType.ROOM_MESSAGE)
-    async def on_message(self, evt: MessageEvent) -> None:#
-        msgtypes = tuple()
-        if self.config["msgtypes.text"]:
-            msgtypes += (MessageType.TEXT,)
-        if self.config["msgtypes.notice"]:
-            msgtypes += (MessageType.NOTICE,)
-
-        self.log.info(f"config: {self.config['msgtypes.text']} {self.config['msgtypes.notice']}")
-        self.log.info(f"listening for msgtypes: {msgtypes}")
-
-        if evt.content.msgtype not in msgtypes or evt.content.body.startswith("!"):
+    async def on_message(self, evt: MessageEvent) -> None:
+        if (evt.content.msgtype != MessageType.TEXT or
+            evt.content.body.startswith("!") or
+            (self.config["respond_to_notice"] and (evt.content.msgtype != MessageType.TEXT or evt.content.msgtype != MessageType.NOTICE))):
             return
 
-        self.log.info(f"received message: {evt.content.body}")
 
         for url_tup in youtube_pattern.findall(evt.content.body):
             await evt.mark_read()

--- a/socialmediadownload.py
+++ b/socialmediadownload.py
@@ -41,9 +41,9 @@ class SocialMediaDownloadPlugin(Plugin):
 
     @event.on(EventType.ROOM_MESSAGE)
     async def on_message(self, evt: MessageEvent) -> None:
-        if (evt.content.msgtype != MessageType.TEXT or
-            evt.content.body.startswith("!") or
-            (self.config["respond_to_notice"] and (evt.content.msgtype != MessageType.TEXT or evt.content.msgtype != MessageType.NOTICE))):
+        if (evt.content.msgtype != MessageType.TEXT and
+        not (self.config["respond_to_notice"] and evt.content.msgtype == MessageType.NOTICE) or
+        evt.content.body.startswith("!")):
             return
 
 


### PR DESCRIPTION
this adds to the config, defaulting to the previous behavior:
```
msgtypes:
  text: True
  notice: False
```

The bot will only listen to those message types that are enabled. The reason to add this is I want my bots to talk to each other, so they need to be able to read `m.notice`s. Namely, an RSS bot will watch social media and post links when something new appears, and this bot will post the content.

This is a draft PR because recalculating which event types to listen for each `@event.on(EventType.ROOM_MESSAGE)` is obviously not smart, but I couldn't figure out quickly how to do it properly after fiddling with mautrix's config classes for a bit. So here's a POC. What do you think?