### PR TITLE
Guess reddit gallery extensions

### DIFF
--- a/socialmediadownload.py
+++ b/socialmediadownload.py
@@ -275,7 +275,7 @@ class SocialMediaDownloadPlugin(Plugin):
                         media_url = (media_info['s']['u']).replace("preview", "i")
                         mime_type = media_info['m']
                         file_extension = mimetypes.guess_extension(mime_type, strict=False)
-                        file_name = media_id + '' if file_extension is None else file_extension
+                        file_name = f"{media_id}{file_extension or ''}"
                         await self.send_image(evt, media_url, mime_type, file_name)
                     return
                 elif 'secure_media' in post_data and 'reddit_video' in post_data['secure_media']:

--- a/socialmediadownload.py
+++ b/socialmediadownload.py
@@ -274,7 +274,8 @@ class SocialMediaDownloadPlugin(Plugin):
                     for media_id, media_info in post_data['media_metadata'].items():
                         media_url = (media_info['s']['u']).replace("preview", "i")
                         mime_type = media_info['m']
-                        file_name = media_id
+                        file_extension = mimetypes.guess_extension(mime_type)
+                        file_name = media_id + '' if file_extension is None else file_extension
                         await self.send_image(evt, media_url, mime_type, file_name)
                     return
                 elif 'secure_media' in post_data and 'reddit_video' in post_data['secure_media']:

--- a/socialmediadownload.py
+++ b/socialmediadownload.py
@@ -274,7 +274,7 @@ class SocialMediaDownloadPlugin(Plugin):
                     for media_id, media_info in post_data['media_metadata'].items():
                         media_url = (media_info['s']['u']).replace("preview", "i")
                         mime_type = media_info['m']
-                        file_extension = mimetypes.guess_extension(mime_type)
+                        file_extension = mimetypes.guess_extension(mime_type, strict=False)
                         file_name = media_id + '' if file_extension is None else file_extension
                         await self.send_image(evt, media_url, mime_type, file_name)
                     return
@@ -289,7 +289,7 @@ class SocialMediaDownloadPlugin(Plugin):
                 media_url = fallback_url.split('?')[0]
                 mime_type = mimetypes.guess_type(media_url)[0]
 
-            file_extension = mimetypes.guess_extension(mime_type)
+            file_extension = mimetypes.guess_extension(mime_type, strict=False)
             file_name = name + file_extension
 
             if "image" in mime_type and self.config["reddit.image"]:


### PR DESCRIPTION
Fixes 2 parts:

Some clients incl Element Web have  started to require a file extension matching the mime type in images' `filename` (or legacy `body`) attributes and refuse to show images not matching this. Regardless of whether that is appropriate, this makes reddit gallery pictures include a file extension when posted by the bot.

Further, Reddit uses the mime type `image/jpg`, which is strictly speaking not the IANA registered type `image/jpeg`, so strict guessing may fail there.

Here is a built version of this change (plus some debug logging) for testing (rename to .mbp because stupid github): [package.zip](https://github.com/user-attachments/files/27274865/package.zip)
